### PR TITLE
Fix Background Image Issues on About Us & Showcase Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,10 @@ The official website of [Daskom Laboratory](https://daskomlab.com/) serves as th
 - **Projects**: Showcase of various projects worked on by Daskom Laboratory, such as the recruitment platform.
 
 ## Developed by:
-- [Muhammad Zaenal Abidin Abdurrahman](https://github.com/Zendin110206) [ZEN]  
-- [Wijdan Insania Kuncoro](https://github.com/wijdanmkh-insk) [DAN]
-- [Dhiya Isnavisa](https://github.com/DiyArc-350) [DHY]
-- [Aliza Nurfitrian Meizahra](https://github.com/Alizaaaja4) [ALL]  
+- [Aliza Nurfitrian Meizahra](https://github.com/Alizaaaja4) [ALL]
 - [Muh Zaidan Fauzan](https://github.com/Zaidanfzn) [FYN]
+- [Muhammad Zaenal Abidin Abdurrahman](https://github.com/Zendin110206) [ZEN]  
+- [Wijdan Insania Kuncoro](https://github.com/wijdanmkh-insk) [DAN]  
 - [Muhammad Hafiz](https://github.com/mhafiz03) [MHZ]
 
 ---

--- a/app/about/layout.tsx
+++ b/app/about/layout.tsx
@@ -5,7 +5,7 @@ export default function AboutLayout({
 }) {
   return (
     <section className="relative flex flex-col h-screen">
-      <div className="inline-block max-w-7xl text-center justify-center">
+      <div className="inline-block max-w-full text-center justify-center">
         {children}
       </div>
     </section>

--- a/app/dlor/layout.tsx
+++ b/app/dlor/layout.tsx
@@ -5,7 +5,7 @@ export default function DlorLayout({
 }) {
   return (
     <section className="relative flex flex-col h-screen">
-      <div className="inline-block max-w-7xl text-center pt-8 justify-center">
+      <div className="inline-block max-w-full text-center pt-8 justify-center">
         {children}
       </div>
     </section>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,7 +40,7 @@ export default function RootLayout({
         <Providers themeProps={{ attribute: "class", defaultTheme: "light" }}>
           <div className="relative flex flex-col h-screen ">
             <Navbar />
-            <main className="container mx-auto max-w-7xl flex-grow">
+            <main className="container mx-auto max-w-full flex-grow">
               {children}
             </main>
           </div>

--- a/app/project/layout.tsx
+++ b/app/project/layout.tsx
@@ -5,7 +5,7 @@ export default function ProjectLayout({
 }) {
   return (
     <section className="relative flex flex-col h-screen">
-      <div className="inline-block max-w-7xl text-center justify-center">
+      <div className="inline-block max-w-full  text-center justify-center">
         {children}
       </div>
     </section>

--- a/components/caroselEvent.tsx
+++ b/components/caroselEvent.tsx
@@ -11,7 +11,7 @@ export const CaroselEvent = () => {
     { src: '/images/event/fotoasisten.webp', eventName: 'Foto Bersama Asisten' },
     { src: '/images/event/makrab.webp', eventName: 'Malam Keakraban' },
     { src: '/images/event/baksos.webp', eventName: 'Bakti Sosial' },
-    { src: '/images/event/firewallParty.webp', eventName: 'Firewall Party' },
+    { src: '/images/event/firewallParty.webp', eventName: 'Farewell Party' },
   ];
 
   const nextSlide = () => {

--- a/components/contentAbout.tsx
+++ b/components/contentAbout.tsx
@@ -12,10 +12,10 @@ export const ContentAbout = () => {
                         
                         {/* Title - Description */}
                         <div className="lg:w-1/2 sm:mt-16 lg:mt-16 sm:ml-6 lg:ml-6 text-left flex flex-col justify-centersm:px-6 lg:px-0">
-                            <h1 className="text-4xl mt-[-440px] sm:mt-[10px] md:mt-[-680px] xl:mt-[20px] sm:text-5xl md:text-6xl lg:text-6xl font-bold text-forestGreen mb-4 sm:text-left md:text-center lg:text-left text-center">
+                            <h1 className="text-4xl mt-[-440px] sm:mt-[10px] md:mt-[-680px] xl:mt-[20px] sm:text-5xl md:text-6xl lg:text-6xl xl:text-7xl 2xl:text-8xl font-bold text-forestGreen mb-4 sm:text-left md:text-center lg:text-left text-center">
                             Daskom<br></br>Laboratory
                             </h1>
-                            <p className="text-base mt-0 md:mt-20 lg:mt-0 sm:text-lg md:text-2xl lg:text-lg font-semibold text-black text-justify">
+                            <p className="text-base mt-0 md:mt-20 lg:mt-0 xl:mt-6 sm:text-lg md:text-2xl lg:text-lg xl:text-xl font-semibold text-black text-justify">
                             Telkom University’s Computer Basics Lab (Laboratorium Daskom) is
                             a leading C programming lab within the Faculty of Electrical
                             Engineering's Computer Engineering Department. We empower students
@@ -33,7 +33,7 @@ export const ContentAbout = () => {
                 </div>
 
             {/* Galleries Section */}
-            <div className="max-w-5xl mx-auto mt-20 sm:mt-[200px] lg:mt-[200px] px-4">
+            <div className="max-w-6xl mx-auto mt-20 sm:mt-[200px] lg:mt-[200px] px-4">
                 <h2 className="font-semibold text-3xl sm:text-4xl mb-8 text-darkGreen text-center">
                     OUR GALLERIES 📸
                 </h2>
@@ -48,7 +48,7 @@ export const ContentAbout = () => {
             </div>
 
             {/* Location Section */}
-            <div className="max-w-5xl mx-auto mt-24 mb-16 px-4 text-center">
+            <div className="max-w-6xl mx-auto mt-24 mb-16 px-4 text-center">
                 <h2 className="font-semibold text-3xl sm:text-4xl mb-8 text-darkGreen">
                     LOCATION 🏛️
                 </h2>

--- a/components/contentRecruitment.tsx
+++ b/components/contentRecruitment.tsx
@@ -13,10 +13,8 @@ export const ContentRecruitment = () => {
           <h4 className="text-xl sm:text-2xl font-semibold text-center mb-4 text-darkGreen">Persyaratan Umum</h4>
           <ul className="list-disc pl-4 sm:pl-6 space-y-3 text-gray-600 text-left">
             <li>Bertaqwa kepada Tuhan YME.</li>
-            <li>Mahasiswa/i Program Studi S1 Teknik Elektro atau S1 Teknik Fisika Angkatan 2024 (S1 Teknik Telekomunikasi, S1 Teknik Biomedis, dan S1 Teknik Sistem Energi menyusul).</li>
-            <li>Indeks Prestasi (IP) Semester 1 ≥  3.25 (di bawah itu akan dipertimbangkan).</li>
-            <li>Nilai Mata Kuliah (MK) Algoritma dan Pemrograman Minimal B (BC akan dipertimbangkan).</li>
-            <li>Nilai Praktikum Algoritma dan Pemrograman Minimal AB.</li>
+            <li>Mahasiswa program studi S1 Teknik Telekomunikasi, S1 Teknik Biomedis, dan S1 Teknik Sistem Energi Angkatan 2024.</li>
+            <li>Indeks Prestasi (IP) Semester 1 ≥ 3.00 di bawah itu akan dipertimbangkan.</li>
           </ul>
         </div>
 
@@ -24,10 +22,10 @@ export const ContentRecruitment = () => {
         <div className="bg-gradient-to-r from-gray-100 to-white p-4 sm:p-6 rounded-lg shadow-lg">
           <h4 className="text-xl sm:text-2xl font-semibold text-center mb-4 text-darkGreen">Persyaratan Khusus</h4>
           <ul className="list-disc pl-4 sm:pl-6 space-y-3 text-gray-600 text-left">
-            <li>CV ATS (Sesuai template yang tersedia atau menggunakan format pribadi, namun masih format yang sama).</li>
-            <li>Biodata (Sesuai dengan template).</li>
+            <li>CV ATS (Dapat menggunakan template yang sudah disediakan, namun diperbolehkan apabila menggunakan template CV yang disediakan asal tetap menggunakan format ATS)</li>
+            <li>Biodata (Sesuai dengan format).</li>
             <li>Transkrip Nilai (KHS) Semester 1.</li>
-            <li>Foto Formal Full Body Ukuran 4R Berwarna (Format JPG/JPEG, menggunakan pakaian yang sopan, dengan latar belakang bebas polos).</li>
+            <li>Foto Formal Full Body Ukuran 4R Berwarna (Format JPG/JPEG, mengenakan pakaian yang sopan, dengan latar belakang bebas polos).</li>
             <li>Visi, Misi, Motivasi Mengikuti Rekrutmen, dan Ide Inovasi untuk Laboratorium Dasar Komputer.</li>
             <li>Surat Lamaran yang Ditujukan kepada Koordinator Asisten dan Pembina Laboratorium.</li>
             <li>Mengisi Formulir Pendaftaran Calon Asisten Laboratorium Dasar Komputer 2025/2026.</li>
@@ -39,7 +37,7 @@ export const ContentRecruitment = () => {
       <div className="flex justify-center mt-14 mb-8 gap-8">
         {/* Apply Now Button */}
         <a
-          href="https://forms.gle/Ki1gkWtAEEEZLhjs5"  // GForm Link
+          href="https://forms.gle/EXaBkcZdwEi2bTVy9"  // GForm Link
           target="_blank"
           rel="noopener noreferrer"
           className="bg-gradient-to-r from-darkGreen to-lightGreen text-white py-3 px-10 rounded-full text-md font-semibold hover:bg-green-700 transition duration-300 transform hover:scale-105"

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -5,6 +5,7 @@ import { IconSvgProps } from "@/types";
 
 export const Logo: React.FC = () => (
   <>
+  {/* ukuran layar lg */}
     <img
       src="/Logo Navbar (sesudah).svg" 
       className="hidden sm:block"
@@ -12,6 +13,8 @@ export const Logo: React.FC = () => (
       width={120}
       height={120}  
     />
+
+    {/* ukuran layar md - sm */}
     <img
       src="/daskom icon.svg" 
       alt="Logo"
@@ -125,13 +128,30 @@ export const NextUILogo: React.FC<IconSvgProps> = (props) => {
 
 export const AboutProfile: React.FC = () => (
   <>
+    {/* Untuk layar 2XL (≥1440px) */}
     <img
       src="/images/background/aboutProfile.png"
       alt="About Profile"
-      className="hidden md:hidden xl:block rounded-lg object-cover drop-shadow-lg"
+      className="hidden 2xl:block rounded-lg object-cover drop-shadow-lg"
+      width={1920} // Bisa disesuaikan dengan resolusi lebih besar
+      height={600}
+      style={{
+        objectFit: "cover",
+        objectPosition: "center",
+        height: "100vh",
+      }}
+    />
+
+    {/* Untuk layar XL (≥1280px & <1440px) */}
+    <img
+      src="/images/background/aboutProfile.png"
+      alt="About Profile"
+      className="hidden md:hidden xl:block 2xl:hidden rounded-lg object-cover drop-shadow-lg"
       width={1500}
       height={500}
     />
+
+    {/* Untuk layar MD - LG (768px - 1024px) */}
     <img
       src="/images/background/aboutProfile.png"
       alt="About Profile"
@@ -139,11 +159,13 @@ export const AboutProfile: React.FC = () => (
       width={1500}
       height={500}
       style={{
-        objectFit: "cover", 
-        objectPosition: "65% 30%", 
-        height: "100vh", 
+        objectFit: "cover",
+        objectPosition: "65% 30%",
+        height: "100vh",
       }}
     />
+
+    {/* Untuk layar HP kecil (≤640px) */}
     <img
       src="/images/background/aboutProfile.png"
       alt="About Profile"
@@ -151,48 +173,46 @@ export const AboutProfile: React.FC = () => (
       width={1500}
       height={500}
       style={{
-        objectFit: "cover", 
-        objectPosition: "65% 30%", 
-        height: "100vh", 
+        objectFit: "cover",
+        objectPosition: "65% 30%",
+        height: "100vh",
       }}
     />
   </>
 );
 
 export const ProjectBackground: React.FC = () => (
-  <>
+  <div className="relative w-full">
+    {/* Untuk layar kecil (< 640px) */}
     <img
       src="/images/background/projectBackground.png"
       alt="Project Background"
-      className="hidden sm:block md:hidden rounded-lg object-cover drop-shadow-lg"
-      width={1500}
-      height={500}
+      className="w-full h-screen object-cover rounded-lg drop-shadow-lg block sm:hidden"
     />
+
+    {/* Untuk layar menengah (640px - 1023px) */}
     <img
       src="/images/background/projectBackground.png"
       alt="Project Background"
-      className="hidden md:block rounded-lg object-cover drop-shadow-lg"
-      width={1500}
-      height={500}
-      style={{
-        objectFit: "cover", 
-        objectPosition: "65% 30%", 
-        height: "103vh", 
-      }}
+      className="w-full h-screen object-cover rounded-lg drop-shadow-lg hidden sm:block md:hidden"
     />
+
+    {/* Untuk layar besar (1024px - 1439px) */}
     <img
       src="/images/background/projectBackground.png"
       alt="Project Background"
-      className="block sm:hidden rounded-lg object-cover drop-shadow-lg"
-      width={1500}
-      height={500}
-      style={{
-        objectFit: "cover", 
-        objectPosition: "65% 30%", 
-        height: "100vh", 
-      }}
+      className="w-full h-screen object-cover rounded-lg drop-shadow-lg hidden md:block xl:hidden"
+      style={{ objectPosition: "65% 30%", maxHeight: "103vh" }}
     />
-  </>
+
+    {/* Untuk layar ekstra besar (≥1440px) */}
+    <img
+      src="/images/background/projectBackground.png"
+      alt="Project Background"
+      className="w-full h-screen object-cover rounded-lg drop-shadow-lg hidden xl:block"
+      style={{ objectPosition: "center", maxHeight: "103vh" }}
+    />
+  </div>
 );
 
 export const DaskomLogo: React.FC = () => (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -20,9 +24,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "build/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Fixed the background image display on the About Us and Showcase Project pages to ensure proper scaling and positioning for screens ≥1440px:

----
- About us (Before)
![image](https://github.com/user-attachments/assets/59ed9062-4aa7-463e-9870-a00377df3573)

- About us (After)
![image](https://github.com/user-attachments/assets/c0ce9003-7bb8-413d-8918-be0dc119702a)
----
- Project (Before)
![image](https://github.com/user-attachments/assets/17092efb-3303-4484-af68-865574bd2217)

- Project (After)
![image](https://github.com/user-attachments/assets/cd2fff12-13b7-45be-bb36-6da530d21078)
